### PR TITLE
Fix Wiki inner link

### DIFF
--- a/app/src/main/java/com/thirtydegreesray/openhub/ui/widget/webview/HtmlHelper.java
+++ b/app/src/main/java/com/thirtydegreesray/openhub/ui/widget/webview/HtmlHelper.java
@@ -100,7 +100,7 @@ class HtmlHelper {
                                  boolean isDark, @NonNull String backgroundColor,
                                  @NonNull String accentColor, boolean wrapCode) {
         String skin = isDark ? "markdown_dark.css" : "markdown_white.css";
-        mdSource = StringUtils.isBlank(baseUrl) ? mdSource : fixLinks(mdSource, baseUrl);
+        mdSource = StringUtils.isBlank(baseUrl) ? fixWikiLinks(mdSource) : fixLinks(mdSource, baseUrl);
         return generateMdHtml(mdSource, skin, backgroundColor, accentColor, wrapCode);
     }
 
@@ -135,6 +135,21 @@ class HtmlHelper {
     private static String formatCode(@NonNull String codeSource) {
         if (StringUtils.isBlank(codeSource)) return codeSource;
         return codeSource.replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+    }
+
+    private static String fixWikiLinks(@NonNull String source) {
+        Matcher linksMatcher = LINK_PATTERN.matcher(source);
+        while (linksMatcher.find()) {
+            while (linksMatcher.find()) {
+                String oriUrl = linksMatcher.group(1);
+                String fixedUrl;
+                if (oriUrl.startsWith("/") && oriUrl.contains("/wiki/")) {
+                    fixedUrl = "https://github.com" + oriUrl;
+                    source = source.replace("href=\"" + oriUrl + "\"", "href=\"" + fixedUrl + "\"");
+                }
+            }
+        }
+        return source;
     }
 
     private static String fixLinks(@NonNull String source, @NonNull String baseUrl) {

--- a/app/src/main/java/com/thirtydegreesray/openhub/ui/widget/webview/HtmlHelper.java
+++ b/app/src/main/java/com/thirtydegreesray/openhub/ui/widget/webview/HtmlHelper.java
@@ -100,7 +100,9 @@ class HtmlHelper {
                                  boolean isDark, @NonNull String backgroundColor,
                                  @NonNull String accentColor, boolean wrapCode) {
         String skin = isDark ? "markdown_dark.css" : "markdown_white.css";
-        mdSource = StringUtils.isBlank(baseUrl) ? fixWikiLinks(mdSource) : fixLinks(mdSource, baseUrl);
+        mdSource = StringUtils.isBlank(baseUrl) ? mdSource : fixLinks(mdSource, baseUrl);
+        //fix wiki inner url like this "href="/robbyrussell/oh-my-zsh/wiki/Themes"" 
+        mdSource = fixWikiLinks(mdSource);
         return generateMdHtml(mdSource, skin, backgroundColor, accentColor, wrapCode);
     }
 


### PR DESCRIPTION
修复使用双括号写法的Wiki内链 `[[ Item Title ]]`
例子：[oh-my-zsh wiki](https://github.com/robbyrussell/oh-my-zsh/wiki)

